### PR TITLE
Implement paged RSS feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ By default, this will start the server on port 8080. You can then add the follow
 | German         | `http://localhost:8080/feed/de` |
 | English        | `http://localhost:8080/feed/en` |
 
+Feeds can be paged using the `page` query parameter, e.g. `?page=2` will
+return the second page with older entries. Pagination links are included in
+the feed using the [RFC&nbsp;5005](https://www.rfc-editor.org/rfc/rfc5005) link
+relations.
+
 ## Features
 
 * Every 15 minutes, the daily blink websites are checked for a new blink.

--- a/config.mjs
+++ b/config.mjs
@@ -3,5 +3,6 @@ export default {
   headless: true,
   scrapeParallel: false,
   scraperCron: "*/60 * * * *",
-  port: 8080
+  port: 8080,
+  feedPageSize: 50
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blinkist-podcast-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Node.js server providing the daily blinks of blinkist.com as an audio podcast",
   "main": "index.js",
   "engines": {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -8,9 +8,10 @@ import {
 } from "./utils/storage.mjs";
 
 export default class Server {
-  constructor({ port, languages }) {
+  constructor({ port, languages, feedPageSize }) {
     this.port = process.env.PORT || port;
     this.languages = languages;
+    this.feedPageSize = feedPageSize;
   }
 
   run() {
@@ -24,7 +25,14 @@ export default class Server {
       if (this.languages.indexOf(language) < 0) {
         return res.status(400).send("This language is not configured");
       }
-      const feedContent = await createFeedAsync(req, language);
+
+      const page = parseInt(req.query.page);
+      const options =
+        !isNaN(page) && page > 0
+          ? { page, pageSize: this.feedPageSize }
+          : {};
+
+      const feedContent = await createFeedAsync(req, language, options);
       res.set("Content-Type", "application/xml");
       res.send(feedContent);
     });

--- a/src/utils/feed.mjs
+++ b/src/utils/feed.mjs
@@ -2,16 +2,36 @@ import RSS from "rss";
 import {
   getBookDetailsAsync,
   getBookListEntriesAsync,
+  getBookListEntriesPageAsync,
   getBookListLastModifiedDateAsync,
 } from "./storage.mjs";
 import { getBookAudioFinalFilePath } from "./paths.mjs";
 import { getAbsoluteUrl } from "./url.mjs";
 import { getOrCreateRssCacheAsync } from "./cache.mjs";
 
-export async function createFeedAsync(reqOrBaseUrl, language) {
-  const feed = await createFeedBase(reqOrBaseUrl, language);
+export async function createFeedAsync(reqOrBaseUrl, language, options = {}) {
+  const { page = null, pageSize = null } = options;
+  let ids, hasMore = false;
 
-  const ids = await getBookListEntriesAsync(language);
+  if (page != null && pageSize != null) {
+    const offset = (page - 1) * pageSize;
+    ({ entries: ids, hasMore } = await getBookListEntriesPageAsync(
+      language,
+      offset,
+      pageSize
+    ));
+  } else if (pageSize != null) {
+    ({ entries: ids } = await getBookListEntriesPageAsync(language, 0, pageSize));
+  } else {
+    ids = await getBookListEntriesAsync(language);
+  }
+
+  const feed = await createFeedBase(reqOrBaseUrl, language, {
+    page,
+    hasMore,
+    pageSize,
+  });
+
   const books = await Promise.all(ids.map((id) => getBookDetailsAsync(id)));
 
   for (let book of books) {
@@ -55,13 +75,20 @@ export async function createFeedAsync(reqOrBaseUrl, language) {
   return feed.xml();
 }
 
-async function createFeedBase(reqOrBaseUrl, language) {
+async function createFeedBase(reqOrBaseUrl, language, {
+  page = null,
+  hasMore = false,
+  pageSize = null,
+} = {}) {
   const pubDate = await getBookListLastModifiedDateAsync(language);
   const feedImg = getAbsoluteUrl(reqOrBaseUrl, `/assets/cover-${language}.jpg`);
-  return new RSS({
+
+  const feedPath =
+    page != null ? `/feed/${language}?page=${page}` : `/feed/${language}`;
+  const feed = new RSS({
     title: `Daily Blinks ${language.toUpperCase()}`,
     description: "This feed offers the daily blinks from Blinkist",
-    feed_url: getAbsoluteUrl(reqOrBaseUrl, `/feed/${language}`),
+    feed_url: getAbsoluteUrl(reqOrBaseUrl, feedPath),
     site_url: getAbsoluteUrl(reqOrBaseUrl, `/`),
     generator: "Daily Blinks Podcast",
     image_url: feedImg,
@@ -71,6 +98,7 @@ async function createFeedBase(reqOrBaseUrl, language) {
     custom_namespaces: {
       itunes: "http://www.itunes.com/dtds/podcast-1.0.dtd",
       content: "http://purl.org/rss/1.0/modules/content/",
+      atom: "http://www.w3.org/2005/Atom",
     },
     custom_elements: [
       { "itunes:subtitle": "This feed offers the daily blinks from Blinkist" },
@@ -84,6 +112,39 @@ async function createFeedBase(reqOrBaseUrl, language) {
       },
     ],
   });
+
+  const selfUrl = getAbsoluteUrl(reqOrBaseUrl, feedPath);
+  feed.custom_elements.push({
+    "atom:link": {
+      _attr: { rel: "self", href: selfUrl, type: "application/rss+xml" },
+    },
+  });
+
+  if (page != null && page > 1) {
+    const prevUrl = getAbsoluteUrl(
+      reqOrBaseUrl,
+      `/feed/${language}?page=${page - 1}`
+    );
+    feed.custom_elements.push({
+      "atom:link": {
+        _attr: { rel: "prev", href: prevUrl, type: "application/rss+xml" },
+      },
+    });
+  }
+
+  if (page != null && hasMore) {
+    const nextUrl = getAbsoluteUrl(
+      reqOrBaseUrl,
+      `/feed/${language}?page=${page + 1}`
+    );
+    feed.custom_elements.push({
+      "atom:link": {
+        _attr: { rel: "next", href: nextUrl, type: "application/rss+xml" },
+      },
+    });
+  }
+
+  return feed;
 }
 
 function getShowNotes(book, chapterData) {


### PR DESCRIPTION
## Summary
- add configurable feed page size
- implement paged feed generation with RFC5005 `prev`/`next` links
- expose pagination via `page` query parameter
- document new feed usage

## Testing
- `node --check src/utils/feed.mjs`
- `node --check src/server.mjs`
- `node --check src/utils/storage.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68867b76faec832cba968e996ee4c4ff