### PR TITLE
Add configurable AAC bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ relations.
 
 You can limit how many episodes are stored per language by adjusting `episodesToKeep` in `config.mjs`. By default all episodes are kept. Uncomment the sample block in `config.mjs` and change the numbers to fit your needs:
 
+You may also set `audioBitrate` to control the bitrate of the AAC files. Lower values reduce file size, e.g. `80` results in about 80&nbsp;kbit/s.
+
 ```javascript
 export default {
   languages: ["de", "en"],
+  // audioBitrate: 80, // encode using ~80 kbit/s AAC
   // episodesToKeep: {
   //   de: 30,
   //   en: 20

--- a/config.mjs
+++ b/config.mjs
@@ -1,5 +1,7 @@
 export default {
   languages: ["de", "en"],
+  // Uncomment the line below to adjust the AAC encoding bitrate
+  // audioBitrate: 80,
   // Uncomment the block below to limit how many episodes are kept per locale
   // episodesToKeep: {
   //   de: 30, // keep the latest 30 German episodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blinkist-podcast-server",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A Node.js server providing the daily blinks of blinkist.com as an audio podcast",
   "main": "index.js",
   "engines": {

--- a/src/runner.mjs
+++ b/src/runner.mjs
@@ -3,10 +3,11 @@ import cron from "cron";
 import { pruneOldBooksAsync } from "./utils/storage.mjs";
 
 export default class Runner {
-  constructor({ languages, episodesToKeep = {}, scraperCron, scrapeParallel, headless }) {
+  constructor({ languages, episodesToKeep = {}, scraperCron, scrapeParallel, headless, audioBitrate }) {
     this.languages = languages;
     this.scrapeParallel = scrapeParallel;
     this.headless = headless;
+    this.audioBitrate = audioBitrate;
     this.episodesToKeep = episodesToKeep;
 
     this.cronJob = new cron.CronJob(scraperCron, () => {
@@ -31,7 +32,11 @@ export default class Runner {
   }
 
   async singleRun(language) {
-    const scraper = new Scraper({ language, headless: this.headless });
+    const scraper = new Scraper({
+      language,
+      headless: this.headless,
+      audioBitrate: this.audioBitrate,
+    });
     await scraper.scrape();
     const keep = this.episodesToKeep?.[language];
     const limit = Number.isFinite(keep) ? keep : Infinity;

--- a/src/utils/audio.mjs
+++ b/src/utils/audio.mjs
@@ -47,7 +47,7 @@ export async function getChaptersWithAudioLengthsAsync(book) {
   );
 }
 
-export async function concatAudioFilesAsync(book, outFilePath) {
+export async function concatAudioFilesAsync(book, outFilePath, audioBitrate) {
   await trySetFfmpegPathsAsync();
   const chapterFilePaths = await Promise.all(
     book.chapters.map((chapter) => {
@@ -76,8 +76,13 @@ export async function concatAudioFilesAsync(book, outFilePath) {
         resolve();
       })
       .addOptions(["-movflags", "+faststart"])
-      .audioCodec("aac")
-      .mergeToFile(outFilePath);
+      .audioCodec("aac");
+
+    if (audioBitrate) {
+      proc.audioBitrate(audioBitrate);
+    }
+
+    proc.mergeToFile(outFilePath);
   });
 }
 

--- a/src/utils/scraper.mjs
+++ b/src/utils/scraper.mjs
@@ -20,9 +20,10 @@ import Crawler from "./crawler.mjs";
 const BASE_URL = "https://www.blinkist.com";
 
 export default class Scraper {
-  constructor({ language, headless }) {
+  constructor({ language, headless, audioBitrate }) {
     this.language = language;
     this.headless = headless;
+    this.audioBitrate = audioBitrate;
   }
   async scrape() {
     console.log("Start scraping", this.language);
@@ -68,7 +69,11 @@ export default class Scraper {
         bookDetails.title
       );
       const concatAudioFilePath = getBookAudioRawFilePath(bookDetails.id);
-      await concatAudioFilesAsync(bookDetails, concatAudioFilePath);
+      await concatAudioFilesAsync(
+        bookDetails,
+        concatAudioFilePath,
+        this.audioBitrate
+      );
 
       const enrichedAudioFilePath = getBookAudioFinalFilePath(bookDetails.id);
 


### PR DESCRIPTION
## Summary
- make AAC bitrate configurable via `audioBitrate`
- document new option and example usage
- wire bitrate through runner/scraper to audio encoder
- bump version to 1.1.3

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68877ff00a18832c8eb040eee71034b7